### PR TITLE
fix: dont fail tasks depending on python-apt if in check mode

### DIFF
--- a/tasks/install.yaml
+++ b/tasks/install.yaml
@@ -2,11 +2,27 @@
 - name: Update apt cache
   ansible.builtin.apt:
     cache_valid_time: 3600
+  register: redis_update_apt_cache
+  failed_when: >-
+    redis_update_apt_cache.failed
+    and not (
+      ansible_check_mode
+      and 'python3-apt must be installed to use check mode'
+        in (redis_update_apt_cache.msg | default(''))
+    )
 
 - name: Install Redis
   notify: Start Redis
   ansible.builtin.apt:
     name: redis-server
+  register: redis_install_apt_result
+  failed_when: >-
+    redis_install_apt_result.failed
+    and not (
+      ansible_check_mode
+      and 'python3-apt must be installed to use check mode'
+        in (redis_install_apt_result.msg | default(''))
+    )
 
 - when: redis.replication.sentinel
   block:
@@ -14,6 +30,13 @@
       ansible.builtin.apt:
         name: redis-sentinel
       register: redis_install_sentinel_apt_result
+      failed_when: >-
+        redis_install_sentinel_apt_result.failed
+        and not (
+          ansible_check_mode
+          and 'python3-apt must be installed to use check mode'
+            in (redis_install_sentinel_apt_result.msg | default(''))
+        )
 
     - name: Stop Redis Sentinel
       when: redis_install_sentinel_apt_result.changed


### PR DESCRIPTION
Prevent `apt` tasks from failing in check mode when `python3-apt` is missing. The known dependency error is ignored only during --check; other errors still fail normally.
Is matching this specific error message stable enough, or should these tasks instead use `when: not ansible_check_mode?`